### PR TITLE
renames push_to_s3 to push_tar_to_s3

### DIFF
--- a/buildAndPushArchives.sh
+++ b/buildAndPushArchives.sh
@@ -25,7 +25,7 @@ create_tar() {
   popd
 }
 
-push_to_s3() {
+push_tar_to_s3() {
   echo "Pushing to S3..."
   aws s3 cp --acl public-read "$ARTIFACT_TAR" "$S3_BUCKET_DIR"
 }
@@ -39,7 +39,7 @@ main() {
 
   set_context
   create_tar
-  push_to_s3
+  push_tar_to_s3
 }
 
 main


### PR DESCRIPTION
https://github.com/Shippable/archive.prep/issues/13

Should be verified by triggering https://app.shippable.com/github/Shippable/jobs/s3_archive_prep/dashboard by setting the following env
```
JOB_TRIGGERED_BY_NAME: node_repo
```