### PR TITLE
Adds create_zip and push_zip_to_s3

### DIFF
--- a/buildAndPushArchives.sh
+++ b/buildAndPushArchives.sh
@@ -3,10 +3,12 @@
 # Input parameters
 export ARTIFACTS_BUCKET="s3://shippable-artifacts"
 export VERSION=master
+export ZIP_ARTIFACTS_WHITELIST=("node")
 
 set_context() {
   export RES_REPO=$CONTEXT"_repo"
   export ARTIFACT_TAR="/tmp/$CONTEXT-$VERSION.tar.gz"
+  export ARTIFACT_ZIP="/tmp/$CONTEXT-$VERSION.zip"
   export S3_BUCKET_DIR="$ARTIFACTS_BUCKET/$CONTEXT/$VERSION/"
   export ARTIFACT_SRC_DIR=$(shipctl get_resource_state $RES_REPO)
 
@@ -30,6 +32,30 @@ push_tar_to_s3() {
   aws s3 cp --acl public-read "$ARTIFACT_TAR" "$S3_BUCKET_DIR"
 }
 
+create_zip() {
+  pushd $ARTIFACT_SRC_DIR
+  echo "Creating tar $ARTIFACT_ZIP..."
+  rm -rf $ARTIFACT_ZIP
+  git archive --format=zip --output=$ARTIFACT_ZIP --prefix=$CONTEXT/ $VERSION
+  echo "Successfully created $ARTIFACT_ZIP"
+  popd
+}
+
+push_zip_to_s3() {
+  echo "Pushing to S3..."
+  aws s3 cp --acl public-read "$ARTIFACT_ZIP" "$S3_BUCKET_DIR"
+}
+
+is_zip_allowed() {
+  local artifact_to_check=$1
+
+  for artifact in "${ZIP_ARTIFACTS_WHITELIST[@]}"; do
+    [[ "$artifact" == "$artifact_to_check" ]] && return 0
+  done
+
+  return 1
+}
+
 main() {
   echo "JOB_TRIGGERED_BY_NAME="$JOB_TRIGGERED_BY_NAME
 
@@ -40,6 +66,10 @@ main() {
   set_context
   create_tar
   push_tar_to_s3
+  if is_zip_allowed "$CONTEXT"; then
+    create_zip
+    push_zip_to_s3
+  fi
 }
 
 main


### PR DESCRIPTION
https://github.com/Shippable/archive.prep/issues/14

Should be verified by triggering https://app.shippable.com/github/Shippable/jobs/s3_archive_prep/dashboard by setting the following env
```
JOB_TRIGGERED_BY_NAME: node_repo
```

Verified the `is_zip_allowed` function locally by using the following script

```bash
export ZIP_ARTIFACTS_WHITELIST=("node" "reqKick")

is_zip_allowed() {
  local artifact_to_check=$1

  for artifact in "${ZIP_ARTIFACTS_WHITELIST[@]}"; do
    [[ "$artifact" == "$artifact_to_check" ]] && return 0
  done

  return 1
}

is_zip_allowed "node"
echo $?

is_zip_allowed "reqKick"
echo $?

is_zip_allowed "reqkick"
echo $?

is_zip_allowed
echo $?

is_zip_allowed "ss"
echo $?

if is_zip_allowed "node"; then
  echo "inside for node"
fi
if is_zip_allowed "reqKick"; then
  echo "inside for reqKick"
fi
if is_zip_allowed "reqkick"; then
  echo "inside for reqkick"
fi
if is_zip_allowed; then
  echo "inside for empty"
fi
if is_zip_allowed "ss"; then
  echo "inside for ss"
fi
```
Output was

```
$ bash checking.sh 
0
0
1
1
1
inside for node
inside for reqKick
```