### PR TITLE
whitelists reqkick

### DIFF
--- a/buildAndPushArchives.sh
+++ b/buildAndPushArchives.sh
@@ -3,7 +3,7 @@
 # Input parameters
 export ARTIFACTS_BUCKET="s3://shippable-artifacts"
 export VERSION=master
-export ZIP_ARTIFACTS_WHITELIST=("node")
+export ZIP_ARTIFACTS_WHITELIST=("node" "reqKick")
 
 set_context() {
   export RES_REPO=$CONTEXT"_repo"


### PR DESCRIPTION
https://github.com/Shippable/archive.prep/issues/17

Should be verified by triggering https://app.shippable.com/github/Shippable/jobs/s3_archive_prep/dashboard by setting the following env
```
JOB_TRIGGERED_BY_NAME: reqKick_repo
```

and seeing if both tar and zip files are pushed to S3