### PR TITLE
removes prefix for zip creation

### DIFF
--- a/buildAndPushArchives.sh
+++ b/buildAndPushArchives.sh
@@ -36,7 +36,7 @@ create_zip() {
   pushd $ARTIFACT_SRC_DIR
   echo "Creating tar $ARTIFACT_ZIP..."
   rm -rf $ARTIFACT_ZIP
-  git archive --format=zip --output=$ARTIFACT_ZIP --prefix=$CONTEXT/ $VERSION
+  git archive --format=zip --output=$ARTIFACT_ZIP $VERSION
   echo "Successfully created $ARTIFACT_ZIP"
   popd
 }


### PR DESCRIPTION
https://github.com/Shippable/archive.prep/issues/19

Windows node scripts expect all the contents of node repo to be at the root instead of a prefix directory. 

#### Current behaviour
```
.
|-- node
  |-- boot.sh
  |-- initScripts
  |-- lib
  |-- LICENSE
  |-- README.md
  |-- scripts
  |-- shipctl
  `-- usr
```

#### Expected
```
.
|-- boot.sh
|-- initScripts
|-- lib
|-- LICENSE
|-- README.md
|-- scripts
|-- shipctl
`-- usr
```

For tar packages, the api is extracting it and compressing back so that all the contents to the expected structure.
